### PR TITLE
Fix Docker Buildx setup: remove cloud driver configuration

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,10 +24,6 @@ jobs:
           password: ${{ secrets.DOCKER_PAT }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: cloud
-          endpoint: "dockerariff/a-s"
-          install: true
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Remove the cloud driver configuration from Docker Buildx setup to resolve concurrent build limit issues. The workflow now uses the default docker-container driver instead of the cloud driver, which should eliminate build failures caused by exceeding concurrent build limits.