### PR TITLE
Skip Docker publishing for Dependabot PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,9 +4,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
 env:
   REGISTRY: docker.io
   IMAGE_NAME: dockerariff/rust-selfhost-server
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,14 +18,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
       - name: Log in to Docker Hub
+        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ vars.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -34,15 +40,27 @@ jobs:
             type=ref,event=pr
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=v0.1.0,enable={{is_default_branch}}
+      
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        if: github.actor != 'dependabot[bot]'
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: false
+      
+      - name: Build Docker image (Dependabot)
+        if: github.actor == 'dependabot[bot]'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
- Add condition to skip Docker Hub login step when github.actor is 'dependabot[bot]'
- Add condition to skip Docker build and push step for Dependabot PRs
- Add separate build-only step for Dependabot PRs that builds without pushing
- This prevents publishing untested dependency updates to the registry