### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/a-ariff/rust-selfhost-server/security/code-scanning/2](https://github.com/a-ariff/rust-selfhost-server/security/code-scanning/2)

To fix this issue, you should add a `permissions` block explicitly to the workflow file, either at the root level (to apply to all jobs by default) or at the job level for jobs that do not need higher-level permissions. The minimal necessary permission for CI jobs that only check out and build/test code is `contents: read`. The fix should insert the `permissions:` key at the same indentation as `name:` and `on:`, before the `jobs:` block (e.g., after line 2 or after line 6 in this case). This ensures that the workflow's GITHUB_TOKEN only receives `read` access to repository contents, thereby minimizing the risk of privilege escalation or misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
